### PR TITLE
fix(EmployeesController): вынес логику из контроллеров в EmployeeService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/Homeworks/Base/src/PromoCodeFactory.Core/Abstractions/Repositories/IRepository.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.Core/Abstractions/Repositories/IRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using PromoCodeFactory.Core.Domain;
 
@@ -7,14 +8,10 @@ namespace PromoCodeFactory.Core.Abstractions.Repositories
 {
     public interface IRepository<T> where T: BaseEntity
     {
-        Task<IEnumerable<T>> GetAllAsync();
-
-        Task<T> GetByIdAsync(Guid id);
-        
-        Task<T> AddAsync(T entity);
-        
-        Task<bool> DeleteAsync(Guid id);
-        
-        Task<T> UpdateAsync(T entity);
+        Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
+        Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+        Task<T> AddAsync(T entity, CancellationToken cancellationToken = default); 
+        Task<T?> UpdateAsync(T entity, CancellationToken cancellationToken = default);
+        Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     }
 }

--- a/Homeworks/Base/src/PromoCodeFactory.Core/PromoCodeFactory.Core.csproj
+++ b/Homeworks/Base/src/PromoCodeFactory.Core/PromoCodeFactory.Core.csproj
@@ -2,6 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>net7</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+    </ItemGroup>
 
 </Project>

--- a/Homeworks/Base/src/PromoCodeFactory.DataAccess/PromoCodeFactory.DataAccess.csproj
+++ b/Homeworks/Base/src/PromoCodeFactory.DataAccess/PromoCodeFactory.DataAccess.csproj
@@ -2,10 +2,15 @@
 
     <PropertyGroup>
         <TargetFramework>net7</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\PromoCodeFactory.Core\PromoCodeFactory.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Homeworks/Base/src/PromoCodeFactory.DataAccess/Repositories/InMemoryRepository.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.DataAccess/Repositories/InMemoryRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using PromoCodeFactory.Core.Abstractions.Repositories;
 using PromoCodeFactory.Core.Domain;
@@ -16,25 +17,29 @@ namespace PromoCodeFactory.DataAccess.Repositories
             _data = data.ToList();
         }
 
-        public Task<IEnumerable<T>> GetAllAsync()
+        public Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult<IEnumerable<T>>(_data);
         }
 
-        public Task<T> GetByIdAsync(Guid id)
+        public Task<T> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_data.FirstOrDefault(x => x.Id == id));
         }
 
-        public Task<T> AddAsync(T entity)
+        public Task<T> AddAsync(T entity, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             entity.Id = Guid.NewGuid();
             _data.Add(entity);
             return Task.FromResult(entity);
         }
-        
-        public Task<bool> DeleteAsync(Guid id)
+
+        public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var entity = _data.FirstOrDefault(x => x.Id == id);
             if (entity == null)
             {
@@ -44,9 +49,10 @@ namespace PromoCodeFactory.DataAccess.Repositories
             _data.Remove(entity);
             return Task.FromResult(true);
         }
-        
-        public Task<T> UpdateAsync(T entity)
+
+        public Task<T> UpdateAsync(T entity, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var existingEntity = _data.FirstOrDefault(x => x.Id == entity.Id);
             if (existingEntity == null)
             {

--- a/Homeworks/Base/src/PromoCodeFactory.DataAccess/Repositories/InMemoryRepository.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.DataAccess/Repositories/InMemoryRepository.cs
@@ -23,10 +23,10 @@ namespace PromoCodeFactory.DataAccess.Repositories
             return Task.FromResult<IEnumerable<T>>(_data);
         }
 
-        public Task<T> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        public Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(_data.FirstOrDefault(x => x.Id == id));
+            return Task.FromResult<T?>(_data.FirstOrDefault(x => x.Id == id));
         }
 
         public Task<T> AddAsync(T entity, CancellationToken cancellationToken = default)
@@ -50,19 +50,19 @@ namespace PromoCodeFactory.DataAccess.Repositories
             return Task.FromResult(true);
         }
 
-        public Task<T> UpdateAsync(T entity, CancellationToken cancellationToken = default)
+        public Task<T?> UpdateAsync(T entity, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var existingEntity = _data.FirstOrDefault(x => x.Id == entity.Id);
             if (existingEntity == null)
             {
-                return Task.FromResult<T>(null);
+                return Task.FromResult<T?>(null);
             }
 
             _data.Remove(existingEntity);
             _data.Add(entity);
 
-            return Task.FromResult(entity);
+            return Task.FromResult<T?>(entity);
         }
     }
 }

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Controllers/EmployeesController.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Controllers/EmployeesController.cs
@@ -1,236 +1,80 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using PromoCodeFactory.Core.Abstractions.Repositories;
-using PromoCodeFactory.Core.Domain.Administration;
 using PromoCodeFactory.WebHost.Models;
+using PromoCodeFactory.WebHost.Services;
 
 namespace PromoCodeFactory.WebHost.Controllers
 {
     /// <summary>
     /// Сотрудники
     /// </summary>
-    [ApiController]
-    [Route("api/v1/[controller]")]
-    public class EmployeesController : ControllerBase
+[ApiController]
+[Route("api/v1/[controller]")]
+public class EmployeesController : ControllerBase
+{
+    private readonly EmployeeService _employeeService;
+
+    public EmployeesController(EmployeeService employeeService)
     {
-        private readonly IRepository<Employee> _employeeRepository;
-        private readonly IRepository<Role> _rolesRepository;
+        _employeeService = employeeService;
+    }
 
-        public EmployeesController(IRepository<Employee> employeeRepository, IRepository<Role> rolesRepository)
+    [HttpGet]
+    public async Task<ActionResult<List<EmployeeShortResponse>>> GetEmployeesAsync(CancellationToken cancellationToken)
+    {
+        var employees = await _employeeService.GetAllEmployeesAsync(cancellationToken);
+        return Ok(employees);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<EmployeeResponse>> GetEmployeeByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var employee = await _employeeService.GetEmployeeByIdAsync(id, cancellationToken);
+        if (employee == null)
+            return NotFound();
+
+        return Ok(employee);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<EmployeeResponse>> CreateEmployeeAsync(EmployeeCreateRequest request, CancellationToken cancellationToken)
+    {
+        try
         {
-            _employeeRepository = employeeRepository;
-            _rolesRepository = rolesRepository;
+            var employee = await _employeeService.CreateEmployeeAsync(request, cancellationToken);
+            return Ok(employee);
         }
-
-        /// <summary>
-        /// Получить данные всех сотрудников
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet]
-        public async Task<List<EmployeeShortResponse>> GetEmployeesAsync()
+        catch (ArgumentException ex)
         {
-            var employees = await _employeeRepository.GetAllAsync();
-
-            var employeesModelList = employees.Select(x =>
-                new EmployeeShortResponse()
-                {
-                    Id = x.Id,
-                    Email = x.Email,
-                    FullName = x.FullName,
-                }).ToList();
-
-            return employeesModelList;
-        }
-
-        /// <summary>
-        /// Получить данные сотрудника по Id
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("{id:guid}")]
-        public async Task<ActionResult<EmployeeResponse>> GetEmployeeByIdAsync(Guid id)
-        {
-            var employee = await _employeeRepository.GetByIdAsync(id);
-
-            if (employee == null)
-                return NotFound();
-
-            var employeeModel = new EmployeeResponse()
-            {
-                Id = employee.Id,
-                Email = employee.Email,
-                Roles = employee.Roles.Select(x => new RoleItemResponse()
-                {
-                    Name = x.Name,
-                    Description = x.Description
-                }).ToList(),
-                FullName = employee.FullName,
-                AppliedPromocodesCount = employee.AppliedPromocodesCount
-            };
-
-            return employeeModel;
-        }
-        
-        /// <summary>
-        /// Создание нового сотрудника
-        /// </summary>
-        /// <returns></returns>
-        [HttpPost]
-        public async Task<ActionResult<EmployeeResponse>> CreateEmployeeAsync(EmployeeCreateRequest request)
-        {
-            // Проверка корректности email
-            var emailAttribute = new EmailAddressAttribute();
-            if (!emailAttribute.IsValid(request.Email))
-            {
-                return BadRequest(new { Error = "Некорректный формат email" });
-            }
-            
-            // Проверка корректности формата Guid для RoleIds
-            var validRoleIds = new List<Guid>();
-            var invalidRoleIds = new List<string>();
-
-            foreach (var roleId in request.RoleIdList)
-            {
-                if (Guid.TryParse(roleId, out var validGuid))
-                {
-                    validRoleIds.Add(validGuid);
-                }
-                else
-                {
-                    invalidRoleIds.Add(roleId);
-                }
-            }
-
-            // Если есть некорректные RoleIds, возвращаем ошибку
-            if (invalidRoleIds.Any())
-            {
-                return BadRequest(new { Error = $"Некорректный формат id ролей" });
-            }
-
-            // Получаем роли из базы по валидным Id
-            var roles = await _rolesRepository.GetAllAsync();
-            var employeeRoles = roles.Where(role => validRoleIds.Contains(role.Id)).ToList();
-
-            // Проверяем, что все роли найдены
-            var missingRoleIds = validRoleIds.Except(employeeRoles.Select(r => r.Id)).ToList();
-            if (missingRoleIds.Any())
-            {
-                return BadRequest(new { Error = $"Роли не найдены для Id: {string.Join(", ", missingRoleIds)}" });
-            }
-
-            // Создаем нового сотрудника
-            var newEmployee = new Employee
-            {
-                Id = Guid.NewGuid(),
-                FirstName = request.FirstName,
-                LastName = request.LastName,
-                Email = request.Email,
-                Roles = employeeRoles,
-                AppliedPromocodesCount = 0
-            };
-
-            await _employeeRepository.AddAsync(newEmployee);
-            
-            return Ok(new EmployeeResponse
-            {
-                Id = newEmployee.Id,
-                Email = newEmployee.Email,
-                FullName = newEmployee.FullName,
-                Roles = newEmployee.Roles.Select(role => new RoleItemResponse
-                {
-                    Id = role.Id,
-                    Name = role.Name,
-                    Description = role.Description
-                }).ToList(),
-                AppliedPromocodesCount = newEmployee.AppliedPromocodesCount
-            });
-        }
-        
-        /// <summary>
-        /// Удаление сотрудника по Id
-        /// </summary>
-        /// <returns></returns>
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteEmployeeAsync(string id)
-        {
-            // Проверка формата Guid
-            if (!Guid.TryParse(id, out var employeeId))
-            {
-                return BadRequest(new { Error = "Некорректный формат идентификатора." });
-            }
-
-            var employee = await _employeeRepository.GetByIdAsync(employeeId);
-            if (employee == null)
-            {
-                return NotFound(new { Error = "Сотрудник не найден." });
-            }
-
-            await _employeeRepository.DeleteAsync(employeeId);
-            return NoContent();
-        }
-        
-        /// <summary>
-        /// Обновление сотрудника по Id
-        /// </summary>
-        /// <returns></returns>
-        [HttpPut("{id:guid}")]
-        public async Task<IActionResult> UpdateEmployeeAsync(Guid id, EmployeeUpdateRequest request)
-        {
-            var employee = await _employeeRepository.GetByIdAsync(id);
-            if (employee == null)
-            {
-                return NotFound(new { Error = "Сотрудник не найден" });
-            }
-
-            var emailAttribute = new EmailAddressAttribute();
-            if (!emailAttribute.IsValid(request.Email))
-            {
-                return BadRequest(new { Error = "Некорректный формат id ролей" });
-            }
-
-            var validRoleIds = new List<Guid>();
-            var invalidRoleIds = new List<string>();
-
-            foreach (var roleId in request.RoleIdList)
-            {
-                if (Guid.TryParse(roleId.ToString(), out var validGuid))
-                {
-                    validRoleIds.Add(validGuid);
-                }
-                else
-                {
-                    invalidRoleIds.Add(roleId);
-                }
-            }
-
-            if (invalidRoleIds.Any())
-            {
-                return BadRequest(new { Error = $"Некорректный формат id ролей" });
-            }
-
-            // Получаем роли из базы по валидным Id
-            var roles = await _rolesRepository.GetAllAsync();
-            var employeeRoles = roles.Where(role => validRoleIds.Contains(role.Id)).ToList();
-
-            // Проверка существования ролей
-            var missingRoleIds = validRoleIds.Except(employeeRoles.Select(r => r.Id)).ToList();
-            if (missingRoleIds.Any())
-            {
-                return BadRequest(new { Error = $"Роли не найдены для id" });
-            }
-
-            // Обновляем поля сотрудника
-            employee.FirstName = request.FirstName;
-            employee.LastName = request.LastName;
-            employee.Email = request.Email;
-            employee.Roles = employeeRoles;
-
-            await _employeeRepository.UpdateAsync(employee);
-
-            return NoContent();
+            return BadRequest(new { Error = ex.Message });
         }
     }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteEmployeeAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _employeeService.DeleteEmployeeAsync(id, cancellationToken);
+        if (!result)
+            return NotFound(new { Error = "Сотрудник не найден." });
+
+        return NoContent();
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateEmployeeAsync(Guid id, EmployeeUpdateRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _employeeService.UpdateEmployeeAsync(id, request, cancellationToken);
+            return NoContent();
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Error = ex.Message });
+        }
+    }
+}
 }

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Controllers/EmployeesController.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Controllers/EmployeesController.cs
@@ -9,72 +9,110 @@ using PromoCodeFactory.WebHost.Services;
 namespace PromoCodeFactory.WebHost.Controllers
 {
     /// <summary>
-    /// Сотрудники
+    /// Контроллер для управления сотрудниками.
     /// </summary>
-[ApiController]
-[Route("api/v1/[controller]")]
-public class EmployeesController : ControllerBase
-{
-    private readonly EmployeeService _employeeService;
-
-    public EmployeesController(EmployeeService employeeService)
+    [ApiController]
+    [Route("api/v1/[controller]")]
+    public class EmployeesController : ControllerBase
     {
-        _employeeService = employeeService;
-    }
+        private readonly EmployeeService _employeeService;
 
-    [HttpGet]
-    public async Task<ActionResult<List<EmployeeShortResponse>>> GetEmployeesAsync(CancellationToken cancellationToken)
-    {
-        var employees = await _employeeService.GetAllEmployeesAsync(cancellationToken);
-        return Ok(employees);
-    }
-
-    [HttpGet("{id:guid}")]
-    public async Task<ActionResult<EmployeeResponse>> GetEmployeeByIdAsync(Guid id, CancellationToken cancellationToken)
-    {
-        var employee = await _employeeService.GetEmployeeByIdAsync(id, cancellationToken);
-        if (employee == null)
-            return NotFound();
-
-        return Ok(employee);
-    }
-
-    [HttpPost]
-    public async Task<ActionResult<EmployeeResponse>> CreateEmployeeAsync(EmployeeCreateRequest request, CancellationToken cancellationToken)
-    {
-        try
+        /// <summary>
+        /// Конструктор контроллера сотрудников.
+        /// </summary>
+        /// <param name="employeeService">Сервис для работы с сотрудниками.</param>
+        public EmployeesController(EmployeeService employeeService)
         {
-            var employee = await _employeeService.CreateEmployeeAsync(request, cancellationToken);
+            _employeeService = employeeService;
+        }
+
+        /// <summary>
+        /// Получить список всех сотрудников.
+        /// </summary>
+        /// <param name="cancellationToken">Токен отмены операции.</param>
+        /// <returns>Список краткой информации о сотрудниках.</returns>
+        [HttpGet]
+        public async Task<ActionResult<List<EmployeeShortResponse>>> GetEmployeesAsync(CancellationToken cancellationToken)
+        {
+            var employees = await _employeeService.GetAllEmployeesAsync(cancellationToken);
+            return Ok(employees);
+        }
+
+        /// <summary>
+        /// Получить информацию о сотруднике по идентификатору.
+        /// </summary>
+        /// <param name="id">Идентификатор сотрудника.</param>
+        /// <param name="cancellationToken">Токен отмены операции.</param>
+        /// <returns>Полная информация о сотруднике.</returns>
+        [HttpGet("{id:guid}")]
+        public async Task<ActionResult<EmployeeResponse>> GetEmployeeByIdAsync(Guid id, CancellationToken cancellationToken)
+        {
+            var employee = await _employeeService.GetEmployeeByIdAsync(id, cancellationToken);
+            if (employee == null)
+                return NotFound();
+
             return Ok(employee);
         }
-        catch (ArgumentException ex)
+
+        /// <summary>
+        /// Создать нового сотрудника.
+        /// </summary>
+        /// <param name="request">Данные для создания сотрудника.</param>
+        /// <param name="cancellationToken">Токен отмены операции.</param>
+        /// <returns>Информация о созданном сотруднике.</returns>
+        [HttpPost]
+        public async Task<ActionResult<EmployeeResponse>> CreateEmployeeAsync(EmployeeCreateRequest request, CancellationToken cancellationToken)
         {
-            return BadRequest(new { Error = ex.Message });
+            try
+            {
+                var employee = await _employeeService.CreateEmployeeAsync(request, cancellationToken);
+                return Ok(employee);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { Error = ex.Message });
+            }
         }
-    }
 
-    [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> DeleteEmployeeAsync(Guid id, CancellationToken cancellationToken)
-    {
-        var result = await _employeeService.DeleteEmployeeAsync(id, cancellationToken);
-        if (!result)
-            return NotFound(new { Error = "Сотрудник не найден." });
-
-        return NoContent();
-    }
-
-    [HttpPut("{id:guid}")]
-    public async Task<IActionResult> UpdateEmployeeAsync(Guid id, EmployeeUpdateRequest request, CancellationToken cancellationToken)
-    {
-        try
+        /// <summary>
+        /// Удалить сотрудника по идентификатору.
+        /// </summary>
+        /// <param name="id">Идентификатор сотрудника.</param>
+        /// <param name="cancellationToken">Токен отмены операции.</param>
+        /// <returns>Статус операции удаления.</returns>
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> DeleteEmployeeAsync(Guid id, CancellationToken cancellationToken)
         {
-            await _employeeService.UpdateEmployeeAsync(id, request, cancellationToken);
+            var result = await _employeeService.DeleteEmployeeAsync(id, cancellationToken);
+            if (!result)
+                return NotFound(new { Error = "Сотрудник не найден." });
+
             return NoContent();
         }
-        catch (ArgumentException ex)
+
+        /// <summary>
+        /// Обновить данные сотрудника.
+        /// </summary>
+        /// <param name="id">Идентификатор сотрудника.</param>
+        /// <param name="request">Данные для обновления сотрудника.</param>
+        /// <param name="cancellationToken">Токен отмены операции.</param>
+        /// <returns>Статус операции обновления.</returns>
+        [HttpPut("{id:guid}")]
+        public async Task<IActionResult> UpdateEmployeeAsync(Guid id, EmployeeUpdateRequest request, CancellationToken cancellationToken)
         {
-            return BadRequest(new { Error = ex.Message });
+            try
+            {
+                await _employeeService.UpdateEmployeeAsync(id, request, cancellationToken);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex) // Если сотрудник не найден
+            {
+                return NotFound(new { Error = ex.Message });
+            }
+            catch (ArgumentException ex) // Если переданы некорректные данные
+            {
+                return BadRequest(new { Error = ex.Message });
+            }
         }
     }
-}
 }

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Models/EmployeeCreateRequest.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Models/EmployeeCreateRequest.cs
@@ -1,13 +1,20 @@
-using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace PromoCodeFactory.WebHost.Models
 {
     public class EmployeeCreateRequest
     {
+        [Required]
         public string FirstName { get; set; }
+        
+        [Required]
         public string LastName { get; set; }
+        
+        [Required]
         public string Email { get; set; }
+        
+        [Required]
         public List<string> RoleIdList { get; set; }
     }
 }

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Models/EmployeeUpdateRequest.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Models/EmployeeUpdateRequest.cs
@@ -1,13 +1,20 @@
-using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace PromoCodeFactory.WebHost.Models
 {
     public class EmployeeUpdateRequest
     {
+        [Required]
         public string FirstName { get; set; }
+        
+        [Required]
         public string LastName { get; set; }
+        
+        [Required]
         public string Email { get; set; }
+        
+        [Required]
         public List<string> RoleIdList { get; set; }
     }
 }

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/PromoCodeFactory.WebHost.csproj
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/PromoCodeFactory.WebHost.csproj
@@ -4,9 +4,11 @@
         <TargetFramework>net8.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
       <PackageReference Include="NSwag.AspNetCore" Version="14.0.7" />
     </ItemGroup>
 

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Services/EmployeeService.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Services/EmployeeService.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PromoCodeFactory.Core.Abstractions.Repositories;
+using PromoCodeFactory.Core.Domain.Administration;
+using PromoCodeFactory.WebHost.Models;
+
+namespace PromoCodeFactory.WebHost.Services
+{
+    public class EmployeeService
+    {
+        private readonly IRepository<Employee> _employeeRepository;
+        private readonly IRepository<Role> _rolesRepository;
+
+        public EmployeeService(IRepository<Employee> employeeRepository, IRepository<Role> rolesRepository)
+        {
+            _employeeRepository = employeeRepository;
+            _rolesRepository = rolesRepository;
+        }
+
+        public async Task<List<EmployeeShortResponse>> GetAllEmployeesAsync(CancellationToken cancellationToken)
+        {
+            var employees = await _employeeRepository.GetAllAsync(cancellationToken);
+            return employees.Select(x => new EmployeeShortResponse
+            {
+                Id = x.Id,
+                Email = x.Email,
+                FullName = x.FullName
+            }).ToList();
+        }
+
+        public async Task<EmployeeResponse> GetEmployeeByIdAsync(Guid id, CancellationToken cancellationToken)
+        {
+            var employee = await _employeeRepository.GetByIdAsync(id, cancellationToken);
+            if (employee == null)
+                return null;
+
+            return new EmployeeResponse
+            {
+                Id = employee.Id,
+                Email = employee.Email,
+                FullName = employee.FullName,
+                AppliedPromocodesCount = employee.AppliedPromocodesCount,
+                Roles = employee.Roles.Select(r => new RoleItemResponse
+                {
+                    Id = r.Id,
+                    Name = r.Name,
+                    Description = r.Description
+                }).ToList()
+            };
+        }
+
+        public async Task<EmployeeResponse> CreateEmployeeAsync(EmployeeCreateRequest request, CancellationToken cancellationToken)
+        {
+            // Проверка email
+            if (!new EmailAddressAttribute().IsValid(request.Email))
+            {
+                throw new ArgumentException("Некорректный формат email.");
+            }
+
+            // Проверка и получение ролей
+            var validRoleIds = request.RoleIdList
+                .Where(roleId => Guid.TryParse(roleId, out _))
+                .Select(Guid.Parse)
+                .ToList();
+
+            var roles = await _rolesRepository.GetAllAsync(cancellationToken);
+            var employeeRoles = roles.Where(r => validRoleIds.Contains(r.Id)).ToList();
+
+            var missingRoles = validRoleIds.Except(employeeRoles.Select(r => r.Id)).ToList();
+            if (missingRoles.Any())
+            {
+                throw new ArgumentException($"Роли не найдены для Id: {string.Join(", ", missingRoles)}");
+            }
+
+            var newEmployee = new Employee
+            {
+                Id = Guid.NewGuid(),
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                Email = request.Email,
+                Roles = employeeRoles,
+                AppliedPromocodesCount = 0
+            };
+
+            await _employeeRepository.AddAsync(newEmployee, cancellationToken);
+
+            return new EmployeeResponse
+            {
+                Id = newEmployee.Id,
+                Email = newEmployee.Email,
+                FullName = newEmployee.FullName,
+                AppliedPromocodesCount = newEmployee.AppliedPromocodesCount,
+                Roles = newEmployee.Roles.Select(r => new RoleItemResponse
+                {
+                    Id = r.Id,
+                    Name = r.Name,
+                    Description = r.Description
+                }).ToList()
+            };
+        }
+
+        public async Task<bool> DeleteEmployeeAsync(Guid id, CancellationToken cancellationToken)
+        {
+            var employee = await _employeeRepository.GetByIdAsync(id, cancellationToken);
+            if (employee == null)
+                return false;
+
+            await _employeeRepository.DeleteAsync(id, cancellationToken);
+            return true;
+        }
+
+        public async Task UpdateEmployeeAsync(Guid id, EmployeeUpdateRequest request, CancellationToken cancellationToken)
+        {
+            var employee = await _employeeRepository.GetByIdAsync(id, cancellationToken);
+            if (employee == null)
+            {
+                throw new ArgumentException("Сотрудник не найден.");
+            }
+
+            if (!new EmailAddressAttribute().IsValid(request.Email))
+            {
+                throw new ArgumentException("Некорректный формат email.");
+            }
+
+            var validRoleIds = request.RoleIdList
+                .Where(roleId => Guid.TryParse(roleId, out _))
+                .Select(Guid.Parse)
+                .ToList();
+
+            var roles = await _rolesRepository.GetAllAsync(cancellationToken);
+            var employeeRoles = roles.Where(r => validRoleIds.Contains(r.Id)).ToList();
+
+            var missingRoles = validRoleIds.Except(employeeRoles.Select(r => r.Id)).ToList();
+            if (missingRoles.Any())
+            {
+                throw new ArgumentException($"Роли не найдены для Id: {string.Join(", ", missingRoles)}");
+            }
+
+            employee.FirstName = request.FirstName;
+            employee.LastName = request.LastName;
+            employee.Email = request.Email;
+            employee.Roles = employeeRoles;
+
+            await _employeeRepository.UpdateAsync(employee, cancellationToken);
+        }
+    }
+}

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Services/EmployeeService.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Services/EmployeeService.cs
@@ -88,7 +88,6 @@ namespace PromoCodeFactory.WebHost.Services
                 LastName = request.LastName,
                 Email = request.Email,
                 Roles = employeeRoles,
-                AppliedPromocodesCount = 0
             };
 
             await _employeeRepository.AddAsync(newEmployee, cancellationToken);

--- a/Homeworks/Base/src/PromoCodeFactory.WebHost/Startup.cs
+++ b/Homeworks/Base/src/PromoCodeFactory.WebHost/Startup.cs
@@ -6,6 +6,7 @@ using PromoCodeFactory.Core.Abstractions.Repositories;
 using PromoCodeFactory.Core.Domain.Administration;
 using PromoCodeFactory.DataAccess.Data;
 using PromoCodeFactory.DataAccess.Repositories;
+using PromoCodeFactory.WebHost.Services;
 
 namespace PromoCodeFactory.WebHost
 {
@@ -14,6 +15,7 @@ namespace PromoCodeFactory.WebHost
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+            services.AddScoped<EmployeeService>();
             services.AddSingleton(typeof(IRepository<Employee>), (x) => 
                 new InMemoryRepository<Employee>(FakeDataFactory.Employees));
             services.AddSingleton(typeof(IRepository<Role>), (x) => 
@@ -31,17 +33,16 @@ namespace PromoCodeFactory.WebHost
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseOpenApi();
+                app.UseSwaggerUi(x =>
+                {
+                    x.DocExpansion = "list";
+                });
             }
             else
             {
                 app.UseHsts();
             }
-
-            app.UseOpenApi();
-            app.UseSwaggerUi(x =>
-            {
-                x.DocExpansion = "list";
-            });
             
             app.UseHttpsRedirection();
 


### PR DESCRIPTION
В асинхронные методы передавайте токены отмены. Их можно взять из контроллера - HttpContext.RequestAborted.

В метод DeleteEmployeeAsync можно передавать и гуид.

Всякую логику проверок, получения ролей - лучше вынести из контроллера. Чем чище код контроллера - тем лучше.

Советую сделать проект enable. Вы в репозитории в методе UpdateAsync можете вернуть нулл. Но при этом в интерфейсе указано, что возвращаете просто тип. Данная настройка подсветила бы Вам этот момент.

В методе CreateEmployeeAsync не обязательно проставлять AppliedPromocodesCount = 0, так как у значимых типов всегда есть значение. В данном случае, значение по умолчанию 0.

Самое главное - посмотрите на свою опенапи схему в свагере. И Вы увидите, что поля, которые имеют ссылочный тип, допускают значения нулл. Не уверен, что Вы тут подразумевали такое поведение. Чтобы в контрактах строго обозначить, что поле не может быть нуллом - навесьте на свойства атрибут [Required].
